### PR TITLE
2 small typos in master branch

### DIFF
--- a/pySnowRadar/matfunc.py
+++ b/pySnowRadar/matfunc.py
@@ -126,7 +126,7 @@ def h5py_to_dict(hdf5_obj, exclude_names=None):
                     data[k] = v[()].astype(bool).item()
                 # empty attribute stored as 2-element array of type uint64
                 elif v[()].dtype == 'uint64' and v[()].shape == (2,):
-                    data[k] == None
+                    data[k] = None
             else:
                 # need to convert HDF object references into actual data
                 dtype = v[()].dtype
@@ -159,7 +159,7 @@ NC_VAR_NAME_SWAP_LUT = {
     'fasttime': 'Time',
     'altitude': 'Elevation', # the NSIDC user guide lists elevation as 'alt'
     'alt': 'Elevation',      # but the downloaded NC file uses 'altitude'
-    'time': 'UTC_Time'
+    'time': 'UTC_time'
 }
 
 def nc_to_dict(hdf5_obj):


### PR DESCRIPTION
Caught these during recent work on QC/ATM, but thought it would be best to implement in master sooner rather than later...

Both cases are in `matfunc.py`:
  - `h5py_to_dict` changed relational operator (`==`) to assignment operator (`=`)
    - previous behaviour would just run an equivalence check and not assign a value of `None` to the given dictionary key
  - `NSIDC_VAR_NAME_SWAP_LUT` updated `UTC_Time` to `UTC_time`
    - `unified_loader` now appears to correctly read the NSIDC time data array when `load_case='full'`
