### PR TITLE
Add automated PyPI packaging

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,8 +1,9 @@
-name: Publish pySnowRadar to PyPI when new release is published
+name: Publish pySnowRadar to PyPI when new master release is published
 
-on: 
-  release:
-    types: [published]
+on:
+  push:
+    branches:
+      - pypi-package
 
 jobs:
   build-and-publish:
@@ -16,7 +17,7 @@ jobs:
         python-version: 3.7
     - name: Install wheel to build env
       run: python -m pip install wheel --user
-    - name: Build the tarball
+    - name: Build the source dist and wheel
       run: python setup.py sdist bdist_wheel
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,9 +1,11 @@
 name: Publish pySnowRadar to PyPI when new master release is published
 
 on:
-  push:
+  release:
     branches:
-      - pypi-package
+      - master
+    types:
+      - published
 
 jobs:
   build-and-publish:
@@ -19,9 +21,8 @@ jobs:
       run: python -m pip install wheel --user
     - name: Build the source dist and wheel
       run: python setup.py sdist bdist_wheel
-    - name: Publish to TestPyPI
+    - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
-        password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  build-and-publish
+  build-and-publish:
     name: Build and publish pySnowRadar to PyPI
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,25 @@
+name: Publish pySnowRadar to PyPI when new release is published
+
+on: 
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish
+    name: Build and publish pySnowRadar to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup build env (Python 3.7)
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install wheel to build env
+      run: python -m pip install wheel --user
+    - name: Build the tarball
+      run: python setup.py sdist bdist_wheel
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -18,8 +18,9 @@ jobs:
       run: python -m pip install wheel --user
     - name: Build the tarball
       run: python setup.py sdist bdist_wheel
-    - name: Publish to PyPI
+    - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
-        password: ${{ secrets.pypi_password }}
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Clone this repository, create the conda environment and install pySnowRadar:
 
 Check out the Jupyter notebook examples for usage scenarios and code snippets:
 
- - [Batch-processing of multiple NSIDC L1b Deconvoluted SnowRadar products](./notebooks/batch_process_example.ipynb)
- - [Layer retrieval test of AWI SnowRadar product](./notebooks/retrieval_test_awi.ipynb)
- - [Layer retrievel test of OIB SnowRadar product](./notebooks/retrieval_test_oib.ipynb)
+ - [Batch-processing of multiple NSIDC L1b Deconvoluted SnowRadar products](https://github.com/kingjml/pySnowRadar/notebooks/batch_process_example.ipynb)
+ - [Layer retrieval test of AWI SnowRadar product](https://github.com/kingjml/pySnowRadar/notebooks/retrieval_test_awi.ipynb)
+ - [Layer retrievel test of OIB SnowRadar product](https://github.com/kingjml/pySnowRadar/notebooks/retrieval_test_oib.ipynb)
  
 pySnowRadar does not validate interface or snow depth estimates. It is highly recommended that users compare outputs with measurements or references to quantify errors. Users should consider uncertainties including but not limited to surface roughness, salinity, and sidelobes.
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pySnowRadar" %}
-{% set version = "0.0.1" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,13 @@ setup(
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Education',
+        'Topic :: Scientific/Engineering'
         'Intended Audience :: Science/Research',
+        'Intended Audience :: Education',
         'License :: OSI Approved :: MIT License',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3 :: Only',
-        'Topic :: Scientific/Engineering'
     ],
     python_requires='>=3,<3.8',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open('README.md', 'r') as readme:
 
 setup(
     name='pySnowRadar',
-    version='0.0.1',
+    version='1.0.1',
     author='Climate Research Division',
     author_email='',
-    description='A Python package to process data from CRESIS SnowRadar systems',
+    description='A Python3 package to process data from CRESIS SnowRadar systems',
     license='MIT',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -18,7 +18,7 @@ setup(
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Whenever a new release is published from master branch, the workflow is triggered to build the source distribution and wheel before sending them to the PyPI site.

Once this is in place and reasonably stable, we can create a [conda-forge recipe](https://github.com/conda-forge/staged-recipes#getting-started) that hooks into the PyPI listing in order to automate conda-forge builds for pySnowRadar.