### PR TITLE
replace print with logger

### DIFF
--- a/pySnowRadar/geofunc.py
+++ b/pySnowRadar/geofunc.py
@@ -20,7 +20,6 @@ def project_latlon(lon, lat, epsg=3413):
     try:
         dst_proj = Proj(init=f'epsg:{epsg}')
     except RuntimeError:
-        print(f'***Error: Supplied EPSG code \'{epsg}\' unrecognized')
-        return
+        raise ValueError('Supplied EPSG code: %d unrecognized' % epsg)
     trans = partial(transform, SRC_PROJ, dst_proj)
     return trans(lon, lat)

--- a/pySnowRadar/qc.py
+++ b/pySnowRadar/qc.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 import numpy as np
 import pandas as pd
@@ -12,6 +13,7 @@ QC_ELEV_MAX = 0.55  # Max allowable elevation for htopo data (m)
 QC_MAX_DIST = 500   # Max allowable distance from nadir (m). For cropping ATM data (?)
 N_RANGE_BINS = 100  # Number of noise range bins to sample
 
+LOGGER = logging.getLogger(__name__)
 
 def qc_fast(sr, snow_depth):
     '''
@@ -70,11 +72,11 @@ def qc_htopo(sr, htopo, snow_depth):
     '''
     # first thing to check is whether there is any local ATM data on the same day as the sr data
     if not ATM_LOCAL_DIR.exists():
-        print(f'***Error: Local ATM directory does not exist: {ATM_LOCAL_DIR.resolve()}')
+        LOGGER.error('Local ATM directory does not exist: %s' % ATM_LOCAL_DIR)
         return
     atm_data = sorted(ATM_LOCAL_DIR.glob(f'*ATM*_{sr.day}_*.h5'))
     if len(atm_data == 0):
-        print(f'***Error: No ATM data found for date: {sr.day}')
+        LOGGER.error('No ATM data found for date: %s' % sr.day)
         return
     QC3 = np.logical_or(abs(sr.pitch) < QC_PITCH_MAX, abs(sr.roll) < QC_ROLL_MAX)
     

--- a/pySnowRadar/snowradar.py
+++ b/pySnowRadar/snowradar.py
@@ -1,6 +1,7 @@
 import os
 import matplotlib.pyplot as plt
 import warnings
+import logging
 import numpy as np
 from datetime import datetime, timedelta
 from scipy import signal
@@ -21,6 +22,8 @@ CRESIS_RAW_FILE_LUT = {
     'snow9': 'OIB_MAT',
     'snow10': 'OIB_MAT'
 }
+
+LOGGER = logging.getLogger(__name__)
 
 class SnowRadar:
     '''
@@ -47,7 +50,7 @@ class SnowRadar:
                 "Load case: %s not understood. " % l_case +\
                 "Must be one of ['meta', 'full']" 
             )
-        print('Loading: %s (%s)' % (self.file_name, l_case))
+        LOGGER.debug('Loading: %s (%s)', self.file_name, l_case)
         self.load_type = l_case
         self.air_snow = None
         self.snow_ice = None
@@ -313,7 +316,7 @@ class SnowRadar:
         '''        
         # Quick check for existance of non-null 'surface' data attribute 
         if self.surface is None:
-            print('Elevation compensation not possible without surface estimate')
+            LOGGER.warning('Elevation compensation not possible without surface estimate')
             return
 
         # Mikeb: placeholders for commonly-repeated operations


### PR DESCRIPTION
Basically replaces `print` statements with `logging` messages that are off by default.

```
>>> from pySnowRadar import SnowRadar
>>> x = SnowRadar('./path/to/data', l_case='full')
>>> x.as_dict()
{ fname: 'data', ... }
```

No log messages on `SnowRadar` object init ☝️ 

It is up to the user to add a handler in order to see log messages in stdout/stderr, which can be accomplished as follows:

```
>>> import logging
>>> logger = logging.getLogger('pySnowRadar')
>>> sh = logging.StreamHandler()
>>> fmt = logging.Formatter('%(asctime)s | %(name)s | %(message)s', '%Y-%m-%d %H:%M:%S')
>>> sh.addFormatter(fmt)
>>> logger.addHandler(sh)
>>> logger.setLevel(logging.DEBUG) # SnowRadar object init log message is debug-level
>>> x = SnowRadar('./path/to/data', l_case='full')
2077-01-01 12:15:00 | pySnowRadar.snowradar | Loading: data (full)
```